### PR TITLE
Provide module path to npm-download submodule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,12 +3,13 @@
 ###############
 module "lambda_content" {
   source  = "dealmore/download/npm"
-  version = "1.0.0"
+  version = "1.1.0"
 
   module_name    = "@dealmore/tf-next-image-optimization"
   module_version = var.next_image_version
   path_to_file   = "dist.zip"
   use_local      = var.debug_use_local_packages
+  local_cwd      = path.module
 }
 
 resource "random_id" "function_name" {


### PR DESCRIPTION
This fixes an issue in local development:
When referencing a local version of the module and using the `debug_use_local_packages` option, the npm submodule would falsely try to resolve the package from the current cwd rather than from the module's root.