### PR TITLE
Bump milliHQ/download/npm from 1.1.0 to 2.0.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
 ###############
 module "lambda_content" {
   source  = "milliHQ/download/npm"
-  version = "1.1.0"
+  version = "2.0.0"
 
   module_name    = "@millihq/tf-next-image-optimization"
   module_version = var.next_image_version


### PR DESCRIPTION
When upgrading from a previous version of the module, Terraform may fail with an error that the final plan has changed during apply.
That was caused by the milliHQ/download/npm module that downloaded the source of the Lambda in parallel to running the apply.
In 2.0.0 this behavior was fixed, so that Terraform waits until the download is finished before progreeding.

Relates to: https://github.com/milliHQ/terraform-npm-download/issues/3.
Fixes: #68.