### PR TITLE
Bump aws-sdk from 2.880.0 to 2.952.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "typescript": "^4.4.2"
   },
   "resolutions": {
-    "aws-sdk": "2.880.0"
+    "aws-sdk": "2.952.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1453,10 +1453,10 @@ available-typed-arrays@^1.0.2:
   dependencies:
     array-filter "^1.0.0"
 
-aws-sdk@*, aws-sdk@2.880.0, aws-sdk@^2.771.0:
-  version "2.880.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.880.0.tgz#2198818f3b42bdd387e1898c8aab5fcca2409a36"
-  integrity sha512-/dBk3ejw22ED2edzGfmJB83KXDA4wLIw5Hb+2YMhly+gOWecvevy0tML2+YN/cmxyTy+wT0E0sM7fm1v7kmHtw==
+aws-sdk@*, aws-sdk@2.952.0, aws-sdk@^2.771.0:
+  version "2.952.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.952.0.tgz#cfbdf2c4685aed17165f4df8760759cd7659a597"
+  integrity sha512-FZkmOWAyDSQMeD8iioeoSW873ZjPXLfGejr0gNi8kQB7JrllOayPaexpq70aT+7n5bAzArjSIH8OAB+BoHYijA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
AWS Lambda now uses `2.952.0`: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html