### PR TITLE
fix: use relative path as lambda function local package path

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@
 
 module "lambda_content" {
   source  = "milliHQ/download/npm"
-  version = "2.0.0"
+  version = "2.1.0"
 
   module_name    = "@millihq/tf-next-image-optimization"
   module_version = var.next_image_version
@@ -36,7 +36,7 @@ module "image_optimizer" {
   }
 
   create_package         = false
-  local_existing_package = module.lambda_content.abs_path
+  local_existing_package = module.lambda_content.rel_path
 
   allowed_triggers = {
     AllowExecutionFromAPIGateway = {


### PR DESCRIPTION
To avoid unintentional state changes when working in multiple environments,
Use relative path as lambda function local package path.

Before:
```
  # module.next_image_optimizer.module.image_optimizer.aws_lambda_function.this[0] will be created
  + resource "aws_lambda_function" "this" {
      ...
      + filename                       = "/Users/aluc/projects/terraform-aws-next-js-image-optimization/examples/with-existing-cloudfront/.terraform/modules/next_image_optimizer.lambda_content/download/@millihq/tf-next-image-optimization/dist.zip"
      ...
```

As seen in `Before`, if the filename is set to an absolute path, the username is included, and the lambda function is updated even if it is the same source in another user's environment.

After:
```
  # module.next_image_optimizer.module.image_optimizer.aws_lambda_function.this[0] will be created
  + resource "aws_lambda_function" "this" {
      ...
      + filename                       = ".terraform/modules/next_image_optimizer.lambda_content/download/@millihq/tf-next-image-optimization/dist.zip"
      ...
```

In `After`, setting the relative path based on cwd, update is attempted only when the actual source code is changed.

**PR of other related projects:**
- https://github.com/milliHQ/terraform-npm-download/pull/6