### PR TITLE
Upgrade AWS provider to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/examples/with-existing-cloudfront/main.tf
+++ b/examples/with-existing-cloudfront/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/examples/with-next-js-export/main.tf
+++ b/examples/with-next-js-export/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/examples/with-next-js/README.md
+++ b/examples/with-next-js/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }


### PR DESCRIPTION
Make sure that the module is fully compatible with the Terraform AWS Provider Version 4 release.
Upgrade guide: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade