### PR TITLE
Adds option to enable SVG support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,13 +26,15 @@ module "image_optimizer" {
   publish       = true
 
   environment_variables = {
-    NODE_ENV                   = "production"
-    TF_NEXTIMAGE_BASE_ORIGIN   = var.next_image_base_origin
-    TF_NEXTIMAGE_DOMAINS       = jsonencode(var.next_image_domains)
-    TF_NEXTIMAGE_DEVICE_SIZES  = var.next_image_device_sizes != null ? jsonencode(var.next_image_device_sizes) : null
-    TF_NEXTIMAGE_FORMATS       = jsonencode(var.next_image_formats)
-    TF_NEXTIMAGE_IMAGE_SIZES   = var.next_image_image_sizes != null ? jsonencode(var.next_image_image_sizes) : null
-    TF_NEXTIMAGE_SOURCE_BUCKET = var.source_bucket_id
+    NODE_ENV                             = "production"
+    TF_NEXTIMAGE_BASE_ORIGIN             = var.next_image_base_origin
+    TF_NEXTIMAGE_DOMAINS                 = jsonencode(var.next_image_domains)
+    TF_NEXTIMAGE_DEVICE_SIZES            = var.next_image_device_sizes != null ? jsonencode(var.next_image_device_sizes) : null
+    TF_NEXTIMAGE_FORMATS                 = jsonencode(var.next_image_formats)
+    TF_NEXTIMAGE_IMAGE_SIZES             = var.next_image_image_sizes != null ? jsonencode(var.next_image_image_sizes) : null
+    TF_NEXTIMAGE_DANGEROUSLY_ALLOW_SVG   = var.next_image_dangerously_allow_SVG ? jsonencode(var.next_image_dangerously_allow_SVG) : null
+    TF_NEXTIMAGE_CONTENT_SECURITY_POLICY = var.next_image_content_security_policy != null ? jsonencode(var.next_image_content_security_policy) : null
+    TF_NEXTIMAGE_SOURCE_BUCKET           = var.source_bucket_id
   }
 
   create_package         = false

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,18 @@ variable "next_image_image_sizes" {
   default     = null
 }
 
+variable "next_image_dangerously_allow_SVG" {
+  description = "Enable the optimization of SVG images."
+  type        = bool
+  default     = false
+}
+
+variable "next_image_content_security_policy" {
+  description = "Set the value of the Content-Security-Policy header in the response of the image optimizer."
+  type        = string
+  default     = null
+}
+
 variable "lambda_memory_size" {
   description = "Amount of memory in MB the worker Lambda Function can use. Valid value between 128 MB to 10,240 MB, in 1 MB increments."
   type        = number


### PR DESCRIPTION
In Next.js `12.1.0` svg images are no longer optimized by default.
Instead the new options `dangerouslyAllowSVG` & `contentSecurityPolicy` were introduced to the image config: https://nextjs.org/docs/api-reference/next/image#dangerously-allow-svg